### PR TITLE
Only define LCC_ROOT if not already defined

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,7 +13,9 @@ class ServiceProvider extends Provider
      */
     public function register()
     {
-        define('LCC_ROOT', realpath(__DIR__ . '/..'));
+        if (!defined('LCC_ROOT')) {
+            define('LCC_ROOT', realpath(__DIR__ . '/..'));
+        }
         
         $this->mergeConfigFrom(LCC_ROOT.'/config/cookieconsent.php', 'cookieconsent');
 


### PR DESCRIPTION
Firstly, thank you for crafting this package - it is great to use!

When in a testing environment, where the application is refreshed in the same process between tests, the following error occurs after the first test has been executed - no matter if success/failure: `ErrorException: Constant LCC_ROOT already defined`. 

A potential workaround for this error could be to run the tests in separate processes, but this drastically - in my experience - increases the overall runtime of the test suite. 

This PR addresses this by checking if the constant has already been defined in the service provider. I struggled to find a way to test this programmatically - hence no tests have been updated. For normal applications, this condition should always evaluate as `false` and thus proceed with defining the constant. 