### PR TITLE
Change cookie secure value for local env

### DIFF
--- a/src/CookiesManager.php
+++ b/src/CookiesManager.php
@@ -160,7 +160,7 @@ class CookiesManager
             value: json_encode($this->preferences),
             minutes: config('cookieconsent.cookie.duration'),
             domain: config('cookieconsent.cookie.domain'),
-            secure: true
+            secure: (env('APP_ENV') == 'local') ? false : true
         );
     }
 


### PR DESCRIPTION
With Safari browser, the consent cookie wasn't getting saved because "secure" was set to `true`. Therefore, in order to make it work for local development on all browsers, the "secure" mode must be set to `false`.

It work for me like this.

Jordan