### PR TITLE
Feature service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ First, publish the package's files:
     'providers' => ServiceProvider::defaultProviders()->merge([
         // ...
         App\Providers\RouteServiceProvider::class,
-        // Add the line below AFTER "App\Providers\RouteServiceProvider::class,"
+        // IMPORTANT: add the following line AFTER "App\Providers\RouteServiceProvider::class,"
         App\Providers\CookiesServiceProvider::class,
     ])->toArray(),
     ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to customize the consent modal's views:
 
 More on [customization](#customization) below.
 
-Now, we'll have to register and configure the used cookies in the freshly published `App\Providers\CookiesServiceProvider`:
+Now, we'll have to register and configure the used cookies in the freshly published `App\Providers\CookiesServiceProvider::registerCookies()` method:
 
 ```php
 namespace App\Providers;

--- a/src/CookiesServiceProvider.php
+++ b/src/CookiesServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Whitecube\LaravelCookieConsent;
+
+use Illuminate\Support\ServiceProvider;
+
+abstract class CookiesServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register()
+    {
+        $this->booted(function () {
+            $this->registerCookies();
+        });
+    }
+
+    /**
+     * Define the cookies users should be aware of.
+     */
+    abstract protected function registerCookies(): void;
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -32,6 +32,10 @@ class ServiceProvider extends Provider
     public function boot()
     {
         $this->publishes([
+            LCC_ROOT.'/stubs/CookiesServiceProvider.php' => app_path('Providers/CookiesServiceProvider.php'),
+        ], 'laravel-cookie-consent-service-provider');
+
+        $this->publishes([
             LCC_ROOT.'/config/cookieconsent.php' => config_path('cookieconsent.php'),
         ], 'laravel-cookie-consent-config');
 

--- a/stubs/CookiesServiceProvider.php
+++ b/stubs/CookiesServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Providers;
+
+use Whitecube\LaravelCookieConsent\Consent;
+use Whitecube\LaravelCookieConsent\Facades\Cookies;
+use Whitecube\LaravelCookieConsent\CookiesServiceProvider as ServiceProvider;
+
+class CookiesServiceProvider extends ServiceProvider
+{
+    /**
+     * Define the cookies users should be aware of.
+     */
+    protected function registerCookies(): void
+    {
+        // Register Laravel's base cookies under the "required" cookies section:
+        Cookies::essentials()
+            ->session()
+            ->csrf();
+
+        // Register all Analytics cookies at once using one single shorthand method:
+        // Cookies::analytics()
+        //     ->google(env('GOOGLE_ANALYTICS_ID'));
+    
+        // Register custom cookies under the pre-existing "optional" category:
+        // Cookies::optional()
+        //     ->name('darkmode_enabled')
+        //     ->description('This cookie helps us remember your preferences regarding the interface\'s brightness.')
+        //     ->duration(120);
+        //     ->accepted(fn(Consent $consent, MyDarkmode $darkmode) => $consent->cookie(value: $darkmode->getDefaultValue()));
+    }
+}


### PR DESCRIPTION
This PR adds a publishable `CookiesServiceContainer` responsible for calling the cookies definition at the right moment in Laravel's registration/booting lifecycle.

Closes #15.