### PR TITLE
more customization for @cookieconsentbutton

### DIFF
--- a/resources/views/button.blade.php
+++ b/resources/views/button.blade.php
@@ -1,6 +1,6 @@
 <form action="{!! $url !!}" {!! $attributes !!}>
     @csrf
-    <button type="submit" class="{!! $basename !!}__link">
-        <span class="{!! $basename !!}__label">{{ $label }}</span>
+    <button type="submit" {!! $btnattributes !!}>
+        <span class="{!! $basename !!}__label">{!! $label !!}</span>
     </button>
 </form>

--- a/src/CookiesManager.php
+++ b/src/CookiesManager.php
@@ -230,7 +230,7 @@ class CookiesManager
     /**
      * Output a single cookie consent action button.
      */
-    public function renderButton(string $action, ?string $label = null, array $attributes = []): string
+    public function renderButton(string $action, ?string $label = null, array $attributes = [], array $btnattributes = []): string
     {
         $url = match ($action) {
             'accept.all' => route('cookieconsent.accept.all'),
@@ -259,10 +259,19 @@ class CookiesManager
             ->map(fn($value, $attribute) => $attribute . '="' . $value . '"')
             ->implode(' ');
 
+        if(! ($btnattributes['class'] ?? null)) {
+            $btnattributes['class'] = $basename . '__link';
+        }
+
+        $btnattributes = collect($btnattributes)
+            ->map(fn($value, $attribute) => $attribute . '="' . $value . '"')
+            ->implode(' ');
+
         return view('cookie-consent::button', [
             'url' => $url,
             'label' => $label ?? $action, // TODO: use lang file
             'attributes' => $attributes,
+            'btnattributes' => $btnattributes,
             'basename' => $basename,
         ])->render();
     }


### PR DESCRIPTION
* added `btnattributes` for `@cookieconsentbutton` to allow button customizing
* removed button label escaping to allow html labels

Example:
```
@cookieconsentbutton(action: 'reset', label: '<i class="material-icons" style="font-size: 2em">shield</i>',
  attributes: ['id' => 'reset-button', 'class' => 'btn fixed-bottom cookie-reset'],
  btnattributes: ['class' => 'btn bg-transparent', 'style' => 'margin-left: 5px; margin-bottom:5px',
    'data-toggle' => 'tooltip', 'title' => __('cookieConsent::cookies.manage')])
```