### PR TITLE
Anonymize IP for Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ class CookiesServiceProvider extends ServiceProvider
 
         // Register all Analytics cookies at once using one single shorthand method:
         Cookies::analytics()
-            ->google(env('GOOGLE_ANALYTICS_ID'));
+            ->google(
+                id: env('GOOGLE_ANALYTICS_ID')
+                anonymizeIp: env('GOOGLE_ANALYTICS_ANONYMIZE_IP')
+            );
     
         // Register custom cookies under the pre-existing "optional" category:
         Cookies::optional()
@@ -154,11 +157,11 @@ Instead of consenting each cookie individually, users grant consent to those cat
 
 There are 3 base categories included in this package:
 
-1. `Cookies::essentials()`: lists all cookies that add required functionnality to the app. This category cannot be opted-out and automatically contains the package's consent cookie.
+1. `Cookies::essentials()`: lists all cookies that add required functionality to the app. This category cannot be opted-out and automatically contains the package's consent cookie.
     - `Cookies::essentials()->session()`: registers Laravel's "session" cookie (defined in your app's `session.cookie` configuration) ;
     - `Cookies::essentials()->csrf()`: registers [Laravel's "XSRF-TOKEN"](https://laravel.com/docs/10.x/csrf) cookie.
 2. `Cookies::analytics()`: lists all cookies used for statistics and data collection.
-    - `Cookies::analytics()->google(string $trackingId)`: automatically lists all Google Analytics' cookies. **This will also automatically register Google Analytics' JS scripts and inject them to the layout's `<head>` only when consent is granted.** Convenient, huh?
+    - `Cookies::analytics()->google(string $trackingId, bool $anonymizeIp)`: automatically lists all Google Analytics' cookies. **This will also automatically register Google Analytics' JS scripts and inject them to the layout's `<head>` only when consent is granted.** Convenient, huh?
 3. `Cookies::optional()`: lists all cookies that serve some kind of utility feature. Since this category can ben opted-out, linked features should always check if consent has been granted before queuing or relying on their cookies.
 
 You are free to add as many custom categories as you want. To do so, simply call the `category(string $key, ?Closure $maker = null)` method on the `Cookies` facade:

--- a/src/AnalyticCookiesCategory.php
+++ b/src/AnalyticCookiesCategory.php
@@ -9,16 +9,18 @@ class AnalyticCookiesCategory extends CookiesCategory
     /**
      * Define Google Analytics cookies all at once.
      */
-    public function google(string $id): static
+    public function google(string $id, bool $anonymizeIp = true): static
     {
-        $this->group(function(CookiesGroup $group) use ($id) {
+        $this->group(function (CookiesGroup $group) use ($anonymizeIp, $id) {
             $key = (strpos($id, 'G-') === 0) ? substr($id, 2) : $id;
+            $anonymizeIp = $anonymizeIp === true ? 'true' : false;
+
             $group->name(static::GOOGLE_ANALYTICS)
                 ->cookie(fn(Cookie $cookie) => $cookie->name('_ga')
                     ->duration(2 * 365 * 24 * 60)
                     ->description(__('cookieConsent::cookies.defaults._ga'))
                 )
-                ->cookie(fn(Cookie $cookie) => $cookie->name('_ga_'.strtoupper($key))
+                ->cookie(fn(Cookie $cookie) => $cookie->name('_ga_' . strtoupper($key))
                     ->duration(2 * 365 * 24 * 60)
                     ->description(__('cookieConsent::cookies.defaults._ga_ID'))
                 )
@@ -30,10 +32,12 @@ class AnalyticCookiesCategory extends CookiesCategory
                     ->duration(1)
                     ->description(__('cookieConsent::cookies.defaults._gat'))
                 )
-                ->accepted(function(Consent $consent) use ($id) {
-                    $consent->script('<script async src="https://www.googletagmanager.com/gtag/js?id='.$id.'"></script>')
-                        ->script('<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag(\'js\',new Date());gtag(\'config\',\''.$id.'\');</script>');
-                });
+                ->accepted(fn(Consent $consent) => $consent
+                    ->script('<script async src="https://www.googletagmanager.com/gtag/js?id=' . $id . '"></script>')
+                    ->script(
+                        '<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag(\'js\',new Date());gtag(\'config\',\'' . $id . '\', {\'anonymize_ip\':' . $anonymizeIp . '});</script>'
+                    )
+                );
         });
 
         return $this;

--- a/src/AnalyticCookiesCategory.php
+++ b/src/AnalyticCookiesCategory.php
@@ -12,7 +12,7 @@ class AnalyticCookiesCategory extends CookiesCategory
     public function google(string $id, bool $anonymizeIp = true): static
     {
         $this->group(function (CookiesGroup $group) use ($anonymizeIp, $id) {
-            $key = (strpos($id, 'G-') === 0) ? substr($id, 2) : $id;
+            $key = str_starts_with($id, 'G-') ? substr($id, 2) : $id;
             $anonymizeIp = $anonymizeIp === true ? 'true' : false;
 
             $group->name(static::GOOGLE_ANALYTICS)

--- a/stubs/CookiesServiceProvider.php
+++ b/stubs/CookiesServiceProvider.php
@@ -2,9 +2,8 @@
 
 namespace App\Providers;
 
-use Whitecube\LaravelCookieConsent\Consent;
-use Whitecube\LaravelCookieConsent\Facades\Cookies;
 use Whitecube\LaravelCookieConsent\CookiesServiceProvider as ServiceProvider;
+use Whitecube\LaravelCookieConsent\Facades\Cookies;
 
 class CookiesServiceProvider extends ServiceProvider
 {
@@ -20,8 +19,11 @@ class CookiesServiceProvider extends ServiceProvider
 
         // Register all Analytics cookies at once using one single shorthand method:
         // Cookies::analytics()
-        //     ->google(env('GOOGLE_ANALYTICS_ID'));
-    
+        //    ->google(
+        //        id:          env('GOOGLE_ANALYTICS_ID'),
+        //        anonymizeIp: env('GOOGLE_ANALYTICS_ANONYMIZE_IP'),
+        //    );
+
         // Register custom cookies under the pre-existing "optional" category:
         // Cookies::optional()
         //     ->name('darkmode_enabled')


### PR DESCRIPTION
This PR adds the option to anonymize IPs in the Google Analytics pre-configured cookie group.

Right now it is possible to add the anonymize IP config to the Google Analytics snippet by duplicating the GA cookie group, but it would be way nicer an easier to just have this option on the `AnalyticCookiesCategory::google()` method. This feature is also requested in #51.

The readme claims that the package is fully GDPR compliant, which it was not, up until the point where google analytics could have the anonymize IP setting enabled.

* Add `$anonymizeIp` param to `AnalyticCookiesCategory::google()` method
* Update Readme
* Update CookiesServiceProvider.php stub

Please let me know if you have anything you want updated in my PR.