### PR TITLE
fix(js-regex): :bug: Fix Regex Pattern in addScripts Method

### DIFF
--- a/resources/js/Cookies.js
+++ b/resources/js/Cookies.js
@@ -37,7 +37,7 @@ class LaravelCookieConsent {
         }
 
         data.scripts.forEach(script => {
-            const scriptRegex = /<script([^]*)<\/script>/;
+            const scriptRegex = /<script[^]*<\/script>/;
             if (!scriptRegex.test(script)) {
                 console.error('Invalid script tag: ' + script);
             }

--- a/resources/js/Cookies.js
+++ b/resources/js/Cookies.js
@@ -32,12 +32,12 @@ class LaravelCookieConsent {
     }
 
     addScripts(data) {
-        if(!data.scripts) {
+        if (!data.scripts) {
             return;
         }
 
         data.scripts.forEach(script => {
-            const scriptRegex = /<script.*<\/script>/;
+            const scriptRegex = /<script([^]*)<\/script>/;
             if (!scriptRegex.test(script)) {
                 console.error('Invalid script tag: ' + script);
             }
@@ -56,7 +56,7 @@ class LaravelCookieConsent {
     }
 
     addNotice(data) {
-        if(!data.notice) {
+        if (!data.notice) {
             return;
         }
 
@@ -68,7 +68,7 @@ class LaravelCookieConsent {
 
         let tags = tmp.querySelectorAll('[data-cookie-consent]');
 
-        if (! tags.length) {
+        if (!tags.length) {
             return;
         }
 
@@ -85,5 +85,5 @@ class LaravelCookieConsent {
 }
 
 window.addEventListener('load', () => {
-    window.LaravelCookieConsent = new LaravelCookieConsent({config:1});
+    window.LaravelCookieConsent = new LaravelCookieConsent({ config: 1 });
 });


### PR DESCRIPTION
Updated the regular expression in the addScripts method from /<script.*<\/script>/ to /<script([^]*)<\/script>/. This change ensures that the script tags are correctly identified, even if they span multiple lines or contain various attributes, improving the robustness of the script injection process.