### PR TITLE
resolves issue 77

### DIFF
--- a/config/cookieconsent.php
+++ b/config/cookieconsent.php
@@ -55,4 +55,21 @@ return [
 
     'policy' => null,
 
+    /* Google Analytics configuration
+    |--------------------------------------------------------------------------
+    |
+    | If you use Google Analytics, you can configure the package to automatically
+    | load the Google Analytics script when the user gives his consent.
+    |
+    | The ID parameter is required and represents your Google Analytics ID.
+    |
+    | The anonymize parameter is optional and determines whether the user's IP
+    | address should be anonymized before being sent to Google Analytics.
+    |
+    */
+    'google_analytics' => [
+        'id' => env('GOOGLE_ANALYTICS_ID', ""),
+        'anonymize_ip' => env('GOOGLE_ANALYTICS_ANONYMIZE_IP', true)
+    ],
+
 ];

--- a/stubs/CookiesServiceProvider.php
+++ b/stubs/CookiesServiceProvider.php
@@ -20,8 +20,8 @@ class CookiesServiceProvider extends ServiceProvider
         // Register all Analytics cookies at once using one single shorthand method:
         // Cookies::analytics()
         //    ->google(
-        //         config('cookieconsent.google_analytics.id'),
-        //         config('cookieconsent.google_analytics.anonymize_ip')
+        //         id: config('cookieconsent.google_analytics.id'),
+        //         anonymizeIp: config('cookieconsent.google_analytics.anonymize_ip')
         //    );
 
         // Register custom cookies under the pre-existing "optional" category:

--- a/stubs/CookiesServiceProvider.php
+++ b/stubs/CookiesServiceProvider.php
@@ -20,8 +20,8 @@ class CookiesServiceProvider extends ServiceProvider
         // Register all Analytics cookies at once using one single shorthand method:
         // Cookies::analytics()
         //    ->google(
-        //        id:          env('GOOGLE_ANALYTICS_ID'),
-        //        anonymizeIp: env('GOOGLE_ANALYTICS_ANONYMIZE_IP'),
+        //         config('cookieconsent.google_analytics.id'),
+        //         config('cookieconsent.google_analytics.anonymize_ip')
         //    );
 
         // Register custom cookies under the pre-existing "optional" category:


### PR DESCRIPTION
when CookieServiceProvider is using Google with env() helper instead of config() it can cause unit tests to fail

> Whitecube\LaravelCookieConsent\AnalyticCookiesCategory::google(): Argument #1 ($id) must be of type string, null given

![image](https://github.com/user-attachments/assets/162384f8-93b6-4be1-add5-caaf09c0c85e)
