### PR TITLE
Update event listener to use DOMContentLoaded

### DIFF
--- a/resources/js/Cookies.js
+++ b/resources/js/Cookies.js
@@ -84,6 +84,6 @@ class LaravelCookieConsent {
     }
 }
 
-window.addEventListener('load', () => {
+window.addEventListener('DOMContentLoaded', () => {
     window.LaravelCookieConsent = new LaravelCookieConsent({ config: 1 });
 });


### PR DESCRIPTION
Replaced the 'load' event with 'DOMContentLoaded' to ensure the cookie consent initialization runs as soon as the DOM is fully loaded, without waiting for additional resources. This improves performance and reduces potential delays in script execution.