### PR TITLE
Displaying the cookie consent view after DOMContentLoaded

### DIFF
--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -30,11 +30,12 @@ function initCookies() {
     cookies.classList.remove('cookies--no-js');
     cookies.classList.add('cookies--closing');
 
-    setTimeout(function() {
-        cookies.classList.remove('cookies--closing');
-    }, 310);
+    document.addEventListener('DOMContentLoaded',()=>{
+        setTimeout(function() {
+            cookies.classList.remove('cookies--closing');
+        }, 310);
+    })
 }
-
 function configureCookies(event)  {
     event.preventDefault();
     window.LaravelCookieConsent.configure(new FormData(event.target));


### PR DESCRIPTION
Solves https://github.com/whitecube/laravel-cookie-consent/issues/47 and https://github.com/whitecube/laravel-cookie-consent/issues/63.

Added `DOMContentLoaded` to ensure the cookie consent view is shown after the DOM is fully loaded.

I noticed pull request https://github.com/whitecube/laravel-cookie-consent/pull/86 which ensures `window.LaravelCookieConsent` is initialized after `DOMContentLoaded`. With this said, it is still possible for the cookie consent box to be shown before `window.LaravelCookieConsent` is initialized, which would result in undefined errors when clicking on the cookie consent buttons. This PR solves this scenario.

