### PR TITLE
Fixed env vars for newer laravel versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ class CookiesServiceProvider extends ServiceProvider
             // Register all Analytics cookies at once using one single shorthand method:
             Cookies::analytics()
                 ->google(
-                    id: env('GOOGLE_ANALYTICS_ID')
-                    anonymizeIp: env('GOOGLE_ANALYTICS_ANONYMIZE_IP')
+                    id: config('cookieconsent.google_analytics.id')
+                    anonymizeIp: config('cookieconsent.google_analytics.anonymize_ip')
                 );
         
             // Register custom cookies under the pre-existing "optional" category:

--- a/src/CookiesManager.php
+++ b/src/CookiesManager.php
@@ -160,7 +160,7 @@ class CookiesManager
             value: json_encode($this->preferences),
             minutes: config('cookieconsent.cookie.duration'),
             domain: config('cookieconsent.cookie.domain'),
-            secure: (env('APP_ENV') == 'local') ? false : true
+            secure: (config('app.env') == 'local') ? false : true
         );
     }
 


### PR DESCRIPTION
Once the configuration has been cached, the .env file will not be loaded and all calls to the env function for .env variables will return null.

When testing locally I noticed the cookie consent modal would not go away and the cookie wasn't set, the browser was blocking the Set-Cookie call because it was tagged as secure and called from a non secure server