### PR TITLE
Fix: TypeError null is not an object

### DIFF
--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -123,6 +123,8 @@ function close() {
     cookies.classList.add('cookies--closing');
 
     setTimeout(((cookies) => { return () => {
+        if (!cookies.parentNode) return;
+
         let scripts = cookies.parentNode.querySelectorAll('[data-cookie-consent]');
 
         scripts.forEach(script => {


### PR DESCRIPTION
Sentry captured an issue in our Laravel app

```
TypeError

null is not an object (evaluating 'e.parentNode.querySelectorAll')
```

This probably has to do with the way Inertia.js handles page navigation. My understanding is it replaces the contentes of the <body> entirely. This would likely destroy the `cookies.parentNode` element before this setTimeout is completed.

Perhaps an alternative would be to just call `document.querySelectorAll(['data-cookie-consent'])` but that fells like a bigger change then I'm comfortable suggestion for this project.