### PR TITLE
Disable cookie encryption for all routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -7,26 +7,25 @@ use Whitecube\LaravelCookieConsent\Http\Controllers\ScriptController;
 use Whitecube\LaravelCookieConsent\Http\Controllers\AcceptAllController;
 use Whitecube\LaravelCookieConsent\Http\Controllers\ConfigureController;
 use Whitecube\LaravelCookieConsent\Http\Controllers\AcceptEssentialsController;
-Route::withoutMiddleware([EncryptCookies::class])->group(function () {
-    Route::group([
-        'as' => 'cookieconsent.',
-        'domain' => config('cookieconsent.url.domain'),
-        'prefix' => config('cookieconsent.url.prefix'),
-        'middleware' => config('cookieconsent.url.middleware')
-    ], function() {
-        Route::get('script', ScriptController::class)
-            ->name('script');
 
-        Route::post('accept-all', AcceptAllController::class)
-            ->name('accept.all');
+Route::group([
+    'as' => 'cookieconsent.',
+    'domain' => config('cookieconsent.url.domain'),
+    'prefix' => config('cookieconsent.url.prefix'),
+    'middleware' => config('cookieconsent.url.middleware')
+], function () {
+    Route::get('script', ScriptController::class)
+        ->name('script');
 
-        Route::post('accept-essentials', AcceptEssentialsController::class)
-            ->name('accept.essentials');
+    Route::post('accept-all', AcceptAllController::class)
+        ->name('accept.all');
 
-        Route::post('configure', ConfigureController::class)
-            ->name('accept.configuration');
+    Route::post('accept-essentials', AcceptEssentialsController::class)
+        ->name('accept.essentials');
 
-        Route::post('reset', ResetController::class)
-            ->name('reset');
-    });
+    Route::post('configure', ConfigureController::class)
+        ->name('accept.configuration');
+
+    Route::post('reset', ResetController::class)
+        ->name('reset');
 });

--- a/src/CookiesServiceProvider.php
+++ b/src/CookiesServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Whitecube\LaravelCookieConsent;
 
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Support\ServiceProvider;
 
 abstract class CookiesServiceProvider extends ServiceProvider
@@ -26,6 +27,8 @@ abstract class CookiesServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->app->afterResolving(EncryptCookies::class, function (EncryptCookies $middleware) {
+            $middleware->disableFor(config('cookieconsent.cookie.name'));
+        });
     }
 }


### PR DESCRIPTION
Used this way to make it work on Laravel 9 projects. Cover problems reported in #16, #17, #62 and #88 .

According to the [Laravel documentation](https://laravel.com/docs/9.x/middleware#excluding-middleware), excluding middleware work with the withoutMiddleware() method on the route's group.